### PR TITLE
CHAT-8 Add listener for online/offline events

### DIFF
--- a/src/AmbitShell.tsx
+++ b/src/AmbitShell.tsx
@@ -36,7 +36,8 @@ interface ShellContainerProps {
     openPersistenceMenuScreen: (data: OpenPersistentMenuData) => void,
     closePersistentMenu: () => void,
     showGetStartedButton: boolean,
-    onGetStartedButtonClick: () => void
+    onGetStartedButtonClick: () => void,
+    online: boolean
 }
 
 export interface ChatShellProps {
@@ -482,6 +483,17 @@ const GetStarted = (props: any) => (
     </div>
 );
 
+const Offline = (props: any) => (
+    <div
+        style={{
+            height: props.height,
+            lineHeight: `${props.height}px`,
+            textAlign: 'center'
+        }}>
+        {'Offline, reconnecting...'}
+    </div>
+);
+
 class ShellContainer extends React.Component<ShellContainerProps, {}> {
     private shell: any;
     focusInput = () => {
@@ -504,12 +516,13 @@ class ShellContainer extends React.Component<ShellContainerProps, {}> {
             isPersistentMenuOpen,
             closePersistentMenu,
             showGetStartedButton,
-            onGetStartedButtonClick
+            onGetStartedButtonClick,
+            online
         } = this.props;
 
         return (
             <div style={{position: 'absolute', bottom: 0, left: 0, right: 0}}>
-                {!showGetStartedButton &&
+                {(!showGetStartedButton && online) &&
                     <ChatShell 
                         ref={el => this.shell = el}
                         closePersistentMenu={closePersistentMenu}
@@ -525,11 +538,12 @@ class ShellContainer extends React.Component<ShellContainerProps, {}> {
                         onChangeMessage={onChangeText}
                         persistentMenuItems={persistentMenuItems}
                         onHeightChange={shellHeightChanged}
-                        height={shellHeight} />            
+                        height={shellHeight} />
                 }
-                {showGetStartedButton &&
+                {(showGetStartedButton && online) &&
                     <GetStarted height={shellHeight} onClick={onGetStartedButtonClick} />
                 }
+                {!online && <Offline height={shellHeight} />}
             </div>
         );
     }
@@ -566,6 +580,7 @@ export const AmbitShell = connect(
         showGetStartedButton: ownProps.showGetStartedButton,
         onGetStartedButtonClick: ownProps.onGetStartedButtonClick,
         persistentMenuItems: ownProps.persistentMenuItems,
+        online: ownProps.online,
         // from stateProps
         isPersistentMenuOpen: stateProps.isPersistentMenuOpen,
         shellHeight: stateProps.shellHeight,

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -83,7 +83,8 @@ import { Header } from './Header';
 import { AmbitShell } from './AmbitShell';
 
 export interface State {
-    isPersistentMenuOpen: boolean
+    isPersistentMenuOpen: boolean,
+    online: boolean
 }
 
 export class Chat extends React.Component<ChatProps, State> {
@@ -122,7 +123,8 @@ export class Chat extends React.Component<ChatProps, State> {
         }
 
         this.state = {
-            isPersistentMenuOpen: false
+            isPersistentMenuOpen: false,
+            online: true
         };
     }
 
@@ -199,7 +201,14 @@ export class Chat extends React.Component<ChatProps, State> {
                 });
             });
         }
+
+        window.addEventListener('online', this.updateOnlineStatus);
+        window.addEventListener('offline', this.updateOnlineStatus);
     }
+
+    updateOnlineStatus = () => {
+        this.setState({ online: navigator.onLine });
+    };
 
     componentWillUnmount() {
         this.connectionStatusSubscription.unsubscribe();
@@ -209,6 +218,8 @@ export class Chat extends React.Component<ChatProps, State> {
         if (this.botConnection)
             this.botConnection.end();
         window.removeEventListener('resize', this.resizeListener);
+        window.removeEventListener('online', this.updateOnlineStatus);
+        window.removeEventListener('offline', this.updateOnlineStatus);
     }
 
     // At startup we do three render passes:
@@ -226,7 +237,7 @@ export class Chat extends React.Component<ChatProps, State> {
         const state = this.store.getState();
         konsole.log("BotChat.Chat state", state);
 
-        const { isPersistentMenuOpen } = this.state;
+        const { isPersistentMenuOpen, online } = this.state;
 
         // only render real stuff after we know our dimensions
         let header: JSX.Element;
@@ -261,7 +272,8 @@ export class Chat extends React.Component<ChatProps, State> {
                         persistentMenuItems={this.props.persistentMenuItems}
                         shellPlaceholderText={this.props.shellPlaceholderText}
                         isPersistentMenuOpen={isPersistentMenuOpen}
-                        showUpload={!this.props.disableUpload} />                    
+                        showUpload={!this.props.disableUpload}
+                        online={online} />
                     { resize }
                 </div>
             </Provider>


### PR DESCRIPTION
So after a bit of experimenting, it seems that MS DirectLine doesn't correctly propagate connection errors and often doesn't actually detect that the connection is down at all. 

I'll save fixing DirectLine for another day, in the meantime I think this is a step in the right direction - uses the HTML5 online/offline API to (hopefully) prevent the user sending messages when they don't have an internet connection.